### PR TITLE
Fix `similarity_score_treshold` option for the `Retriever` object

### DIFF
--- a/pages/Source_finder.py
+++ b/pages/Source_finder.py
@@ -79,7 +79,11 @@ def main():
     client = chromadb.PersistentClient(path=PERSIST_DIRECTORY)
     db = Chroma(client=client, embedding_function=embeddings)
     retriever = db.as_retriever(
-        search_kwargs={"k": sources_to_retrieve, "score_threshold": similarity_treshold}
+        search_type="similarity_score_threshold",
+        search_kwargs={
+            "score_threshold": similarity_treshold,
+            "k": sources_to_retrieve,
+        },
     )
 
     if query:


### PR DESCRIPTION
Closes #7 